### PR TITLE
Migrate aws_c_common, aws_c_http & aws_c_io

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,11 +1,11 @@
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_sdkutils:
 - 0.1.7
 c_compiler:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -3,11 +3,11 @@ BUILD:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_sdkutils:
 - 0.1.7
 c_compiler:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,11 +1,11 @@
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_sdkutils:
 - 0.1.7
 c_compiler:

--- a/.ci_support/migrations/aws_c_common089.yaml
+++ b/.ci_support/migrations/aws_c_common089.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+aws_c_common:
+- 0.8.9
+migrator_ts: 1673680911.2455108

--- a/.ci_support/migrations/aws_c_http073.yaml
+++ b/.ci_support/migrations/aws_c_http073.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+  automerge: true
+aws_c_http:
+- 0.7.3
+migrator_ts: 1675172490.116017

--- a/.ci_support/migrations/aws_c_io01314.yaml
+++ b/.ci_support/migrations/aws_c_io01314.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+aws_c_io:
+- 0.13.14
+migrator_ts: 1673680924.2678478

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -3,11 +3,11 @@ MACOSX_DEPLOYMENT_TARGET:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_sdkutils:
 - 0.1.7
 c_compiler:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -3,11 +3,11 @@ MACOSX_DEPLOYMENT_TARGET:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_sdkutils:
 - 0.1.7
 c_compiler:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,11 +1,11 @@
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_sdkutils:
 - 0.1.7
 c_compiler:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 016d0f12acfd6d4fce946566ceab3c85aa2a5c48ab72bdf9855201ab9b612903
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("aws-c-auth", max_pin="x.x.x") }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,11 @@
-{% set name = "aws-c-auth" %}
 {% set version = "0.6.23" %}
 
 package:
-  name: {{ name|lower }}
+  name: aws-c-auth
   version: {{ version }}
 
 source:
-  url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
+  url: https://github.com/awslabs/aws-c-auth/archive/v{{ version }}.tar.gz
   sha256: 016d0f12acfd6d4fce946566ceab3c85aa2a5c48ab72bdf9855201ab9b612903
 
 build:


### PR DESCRIPTION
Migrators racing + being pinned to old versions not being ABI-migrated anymore in other parts of the aws-* stack = conflict